### PR TITLE
fixed `docker stop` to trigger clean shutdown for tt executable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,6 @@ LABEL docker.cmd="docker run -d --name ticktock -p 6181-6182:6181-6182 -p 6181:6
 
 HEALTHCHECK --interval=5m --timeout=5s \
   CMD /opt/ticktock/scripts/healthcheck.sh
-STOPSIGNAL SIGINT
 
 RUN apt-get update && apt-get install -y \
   curl \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,6 +19,5 @@ if test -x "/opt/grafana/bin/grafana-server"; then
 fi
 
 # start TickTock
-/opt/ticktock/bin/ticktock -c /var/lib/ticktock/conf/ticktock.conf -r $@
+exec /opt/ticktock/bin/ticktock -c /var/lib/ticktock/conf/ticktock.conf -r $@
 
-exit 0


### PR DESCRIPTION
When using the Docker image to run ticktock I noticed `docker stop` to both take a long time and not cleanly terminating the ticktock executable.
To verify the erroneous behaviour, please:
- `docker run` the origin Docker image with a mounted volume to have the logs outside the container
- `tail -f` the logfile
- `docker stop` the container
  - `docker stop` will hang for a while
  - the logfile will not contain the `[INFO] [main] Shutdown process complete` log
  - when restarting the container you maybe additionally will detect loss of data (old in-memory only data)
 
When drilling down this, the reason/solution was simple -> ticktock has to be run with `exec` in `entrypoint.sh`.
For further explanation please see e.g. https://madflojo.medium.com/shutdown-signals-with-docker-entry-point-scripts-5e560f4e2d45.

This PR contains the according fix.
To verify the fixed behaviour, please re-execute the procedure described above - you should now see the `[INFO] [main] Shutdown process complete` log message.

_Note:_
The `Dockerfile` contains a `STOPSIGNAL SIGINT` statement which isn't really neded (for my opinion). Docker uses `SIGTERM` by default which in my tests seemed to work the same way.